### PR TITLE
feat: implement token option parsing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Run Unit Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the code
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Set up Go environment
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.23
+
+      # Install dependencies
+      - name: Install dependencies
+        run: go mod tidy
+
+      # Run unit tests
+      - name: Run tests
+        run: go test ./... -v

--- a/cmd/option/token.go
+++ b/cmd/option/token.go
@@ -1,0 +1,113 @@
+package option
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// ParseTokenOption parses the token option string and returns the appropriate token.
+// The token option can be one of the following:
+//
+//	none: request without token and follow oauth2
+//	anonymous: get anonymous access token once and share between all instances
+//	token=<token>: use provided token
+func ParseTokenOption(tokenOption string, registry string) (string, error) {
+	switch {
+	case tokenOption == "none":
+		return "", nil
+	case tokenOption == "anonymous":
+		token, err := getAuthToken(registry)
+		if err != nil {
+			return "", err
+		}
+		return token, nil
+	case strings.HasPrefix(tokenOption, "token="):
+		return strings.TrimPrefix(tokenOption, "token="), nil
+	default:
+		return "", fmt.Errorf("invalid token option: %s", tokenOption)
+	}
+}
+
+var getAuthToken = func(registry string) (string, error) {
+	// Get the authentication header
+	client := http.DefaultClient
+	req, err := http.NewRequest("HEAD", fmt.Sprintf("https://%s/v2/", registry), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to perform request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	authHeader := resp.Header.Get("Www-Authenticate")
+	if authHeader == "" {
+		return "", fmt.Errorf("auth header not found")
+	}
+
+	// Parse the realm and service from the auth header
+	realm := parseChallenge(authHeader, "realm")
+	service := parseChallenge(authHeader, "service")
+	if realm == "" || service == "" {
+		return "", fmt.Errorf("failed to parse realm or service from auth header")
+	}
+
+	// Get the token using native Go HTTP client
+	tokenURL := fmt.Sprintf("%s?service=%s&scope=repository:*:pull", realm, service)
+	req, err = http.NewRequest("GET", tokenURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create token request: %v", err)
+	}
+
+	resp, err = client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to perform token request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code while fetching token: %d", resp.StatusCode)
+	}
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(resp.Body); err != nil {
+		return "", fmt.Errorf("failed to read token response body: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		return "", fmt.Errorf("failed to parse token response JSON: %v", err)
+	}
+
+	token, ok := result["access_token"].(string)
+	if !ok {
+		return "", fmt.Errorf("access_token not found or invalid in response")
+	}
+	return token, nil
+}
+
+// parseChallenge extracts the value of a specific key from the WWW-Authenticate header
+// It assumes the format is "key=value" and that the value is enclosed in double quotes.
+// It returns an empty string if the key is not found or if the value is not properly formatted.
+func parseChallenge(header, key string) string {
+	prefix := fmt.Sprintf(`%s="`, key)
+	start := strings.Index(header, prefix)
+	if start == -1 {
+		return ""
+	}
+	start += len(prefix)
+	end := strings.Index(header[start:], `"`)
+	if end == -1 {
+		return ""
+	}
+	return header[start : start+end]
+}

--- a/cmd/option/token_test.go
+++ b/cmd/option/token_test.go
@@ -1,0 +1,103 @@
+package option
+
+import (
+	"errors"
+	"testing"
+)
+
+const (
+	anonymous_registry = "anonymous_registry"
+	mocked_token       = "mocked_token"
+	invalid_registry   = "invalid_registry"
+)
+
+func TestParseTokenOption(t *testing.T) {
+	getAuthToken = func(registry string) (string, error) {
+		if registry == anonymous_registry {
+			return mocked_token, nil
+		}
+		return "", errors.New("invalid registry")
+	}
+
+	type args struct {
+		tokenOption string
+		registry    string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Valid none option, no registry",
+			args: args{
+				tokenOption: "none",
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "Valid anonymous option, valid registry",
+			args: args{
+				tokenOption: "anonymous",
+				registry:    anonymous_registry,
+			},
+			want:    mocked_token,
+			wantErr: false,
+		},
+		{
+			name: "Valid anonymous option, invalid registry",
+			args: args{
+				tokenOption: "anonymous",
+				registry:    invalid_registry,
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Anonymous option with empty registry",
+			args: args{
+				tokenOption: "anonymous",
+				registry:    "",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Valid token option",
+			args: args{
+				tokenOption: "token=mytoken",
+				registry:    "example.com",
+			},
+			want:    "mytoken",
+			wantErr: false,
+		},
+		{
+			name: "Invalid token option",
+			args: args{
+				tokenOption: "invalid",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "Empty token option",
+			args:    args{},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseTokenOption(tt.args.tokenOption, tt.args.registry)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseTokenOption() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ParseTokenOption() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/option/token_test.go
+++ b/cmd/option/token_test.go
@@ -6,15 +6,24 @@ import (
 )
 
 const (
-	anonymous_registry = "anonymous_registry"
-	mocked_token       = "mocked_token"
-	invalid_registry   = "invalid_registry"
+	mocked_anonymous_registry = "anonymous_registry"
+	mocked_auth_registry      = "auth_registry"
+	mocked_invalid_registry   = "invalid_registry"
+	mocked_identity_token     = "mocked_identity_token"
+	mocked_registry_token     = "mocked_registry_token"
+	mocked_invalid_token      = "invalid_token"
 )
 
 func TestParseTokenOption(t *testing.T) {
-	getAuthToken = func(registry string) (string, error) {
-		if registry == anonymous_registry {
-			return mocked_token, nil
+	// Mocking the getAuthToken function
+	getAuthToken = func(registry string, identity_token string) (string, error) {
+		switch {
+		case registry == mocked_anonymous_registry:
+			// mock returning an anonymous registry token
+			return mocked_identity_token, nil
+		case registry == mocked_auth_registry && identity_token == mocked_identity_token:
+			// exchanged registry token
+			return mocked_registry_token, nil
 		}
 		return "", errors.New("invalid registry")
 	}
@@ -41,16 +50,16 @@ func TestParseTokenOption(t *testing.T) {
 			name: "Valid anonymous option, valid registry",
 			args: args{
 				tokenOption: "anonymous",
-				registry:    anonymous_registry,
+				registry:    mocked_anonymous_registry,
 			},
-			want:    mocked_token,
+			want:    mocked_identity_token,
 			wantErr: false,
 		},
 		{
 			name: "Valid anonymous option, invalid registry",
 			args: args{
 				tokenOption: "anonymous",
-				registry:    invalid_registry,
+				registry:    mocked_invalid_registry,
 			},
 			want:    "",
 			wantErr: true,
@@ -65,18 +74,19 @@ func TestParseTokenOption(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Valid token option",
+			name: "Valid exchange",
 			args: args{
-				tokenOption: "token=mytoken",
-				registry:    "example.com",
+				tokenOption: "token=" + mocked_identity_token,
+				registry:    mocked_auth_registry,
 			},
-			want:    "mytoken",
+			want:    mocked_registry_token,
 			wantErr: false,
 		},
 		{
-			name: "Invalid token option",
+			name: "Invalid exchange",
 			args: args{
-				tokenOption: "invalid",
+				tokenOption: "token=" + mocked_invalid_token,
+				registry:    mocked_auth_registry,
 			},
 			want:    "",
 			wantErr: true,

--- a/cmd/test/test.go
+++ b/cmd/test/test.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net"
@@ -15,16 +13,17 @@ import (
 	"time"
 
 	"github.com/billy-playground/registry-load-tester/cmd/internal/runner"
+	"github.com/billy-playground/registry-load-tester/cmd/option"
 )
 
 func main() {
 	// Input arguments:
 	// 0. Input check and help
 	if len(os.Args) < 3 {
-		fmt.Println("Usage: go run main.go <num_instances> <registry_domain> <anonymous_token_required(true/false)> [<registry_endpoint>]")
+		fmt.Println("Usage: go run main.go <num_instances> <registry_domain> <token_mode> [<registry_endpoint>]")
 		fmt.Println("num_instances: Number of instances to run")
 		fmt.Println("registry_domain: Domain of the registry")
-		fmt.Println("anonymous_token_required: Whether an anonymous token is required (true/false)")
+		fmt.Println("token_mode: Token mode (none, anonymous, token=<token>)")
 		fmt.Println("registry_endpoint: Endpoint of the registry (default: registry)")
 		os.Exit(1)
 	}
@@ -33,8 +32,11 @@ func main() {
 	fmt.Sscanf(os.Args[1], "%d", &numInstances)
 	// 2. Registry domain
 	var registry = os.Args[2]
-	// 3. Anonymous token required
-	var anonymousTokenRequired = (strings.ToLower(os.Args[3]) == "true")
+	token, err := option.ParseTokenOption(os.Args[3], registry)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing token option: %v\n", err)
+		os.Exit(1)
+	}
 	// 4. Registry endpoint (default to registry)
 	endpoint := registry
 	if len(os.Args) > 4 {
@@ -47,16 +49,6 @@ func main() {
 				}
 				return net.Dial(network, addr)
 			},
-		}
-	}
-
-	// Get anonymous token
-	var token string
-	if anonymousTokenRequired {
-		var err error
-		if token, err = getAuthToken(registry); err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting auth token: %v\n", err)
-			os.Exit(1)
 		}
 	}
 
@@ -92,85 +84,4 @@ func main() {
 	wg.Wait()
 
 	fmt.Printf("Total time taken: %.2f seconds\n", time.Since(start).Seconds())
-}
-
-func getAuthToken(registry string) (string, error) {
-	// Get the authentication header
-	client := http.DefaultClient
-	req, err := http.NewRequest("HEAD", fmt.Sprintf("https://%s/v2/", registry), nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to create request: %v", err)
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to perform request: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusUnauthorized {
-		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
-
-	authHeader := resp.Header.Get("Www-Authenticate")
-	if authHeader == "" {
-		return "", fmt.Errorf("auth header not found")
-	}
-
-	// Parse the realm and service from the auth header
-	realm := parseChallenge(authHeader, "realm")
-	service := parseChallenge(authHeader, "service")
-	if realm == "" || service == "" {
-		return "", fmt.Errorf("failed to parse realm or service from auth header")
-	}
-
-	// Get the token using native Go HTTP client
-	tokenURL := fmt.Sprintf("%s?service=%s&scope=repository:*:pull", realm, service)
-	req, err = http.NewRequest("GET", tokenURL, nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to create token request: %v", err)
-	}
-
-	resp, err = client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to perform token request: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unexpected status code while fetching token: %d", resp.StatusCode)
-	}
-
-	var buf bytes.Buffer
-	if _, err := buf.ReadFrom(resp.Body); err != nil {
-		return "", fmt.Errorf("failed to read token response body: %v", err)
-	}
-
-	var result map[string]interface{}
-	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
-		return "", fmt.Errorf("failed to parse token response JSON: %v", err)
-	}
-
-	token, ok := result["access_token"].(string)
-	if !ok {
-		return "", fmt.Errorf("access_token not found or invalid in response")
-	}
-	return token, nil
-}
-
-// parseChallenge extracts the value of a specific key from the WWW-Authenticate header
-// It assumes the format is "key=value" and that the value is enclosed in double quotes.
-// It returns an empty string if the key is not found or if the value is not properly formatted.
-func parseChallenge(header, key string) string {
-	prefix := fmt.Sprintf(`%s="`, key)
-	start := strings.Index(header, prefix)
-	if start == -1 {
-		return ""
-	}
-	start += len(prefix)
-	end := strings.Index(header[start:], `"`)
-	if end == -1 {
-		return ""
-	}
-	return header[start : start+end]
 }


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality of token handling and unit testing in the project. The most important changes include the addition of a new token parsing function.

The third argument are now required with below values:
- none: request without token and follow oauth2
- anonymous: get anonymous access token once and share between all instances
- token=<token>: exchange provided <token> to registry token and share between all instances