### PR TITLE
feat: use caching authorization handling

### DIFF
--- a/cmd/internal/runner/runner.go
+++ b/cmd/internal/runner/runner.go
@@ -52,17 +52,16 @@ func (r *Runner) StartNew(fileName string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create repository: %w", err)
 	}
+	client := &auth.Client{
+		Cache:  auth.NewCache(),
+		Client: http.DefaultClient,
+	}
 	if r.accessToken != "" {
-		repo.Client = &auth.Client{
-			Header: http.Header{
-				"Authorization": []string{fmt.Sprintf("Bearer %s", r.accessToken)},
-			},
-		}
-	} else {
-		repo.Client = &auth.Client{
-			Client: http.DefaultClient,
+		client.Header = http.Header{
+			"Authorization": []string{fmt.Sprintf("Bearer %s", r.accessToken)},
 		}
 	}
+	repo.Client = client
 
 	// Download manifest and blobs concurrently
 	var wg sync.WaitGroup


### PR DESCRIPTION
This pull request includes changes to the `cmd/internal/runner/runner.go` file to improve the handling of the authentication client in the `StartNew` function. The most important changes include the creation of a new `auth.Client` instance with a cache and default HTTP client, and the consolidation of the logic for setting the authorization header.