### PR TITLE
fix: update Dockerfile to use correct binary for entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ADD . /src
 RUN rm -rf /src/bin
 WORKDIR /src
 RUN make build  # Static build for amd64
-RUN mv /src/bin/test /go/bin/test
+RUN mv /src/bin/rlt /go/bin/rlt
 RUN mv /src/bin/assets /go/bin/assets
 
 FROM alpine:3.17.1
@@ -12,9 +12,9 @@ RUN apk add file
 RUN apk --update add ca-certificates file
 
 RUN mkdir /app
-COPY --from=builder /go/bin/test /app/test
-RUN chmod +x /app/test
+COPY --from=builder /go/bin/rlt /app/rlt
+RUN chmod +x /app/rlt
 COPY --from=builder /go/bin/assets /app/assets
 
 WORKDIR /app
-ENTRYPOINT ["/app/test"]
+ENTRYPOINT ["/app/rlt"]


### PR DESCRIPTION
This pull request updates the `Dockerfile` to replace references to the `test` binary with a new binary named `rlt`. This change ensures the correct binary is built, copied, and executed in the Docker image.

Key changes:

* Updated the `mv` command to rename `/src/bin/rlt` to `/go/bin/rlt` instead of `/src/bin/test` to `/go/bin/test`. (`Dockerfile`, [DockerfileL7-R20](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L7-R20))
* Replaced all occurrences of `test` with `rlt` in the `COPY` and `ENTRYPOINT` instructions, ensuring the new binary is properly copied and executed in the container. (`Dockerfile`, [DockerfileL7-R20](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L7-R20))