### PR TITLE
docs: update README and move help into cobra commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This project is a load testing tool for a registry. It allows you to pre-bake workload and simulate concurrent instances to pull from a registry to evaluate its performance.
 
+## Build
+
+Before running the tool, build the binary:
+
+```bash
+make build
+```
+
 ## Usage
 
 Run the tool using the following command:
@@ -10,31 +18,13 @@ Run the tool using the following command:
 go run main.go <num_instances>[=<size>/<interval>] <registry_domain> <token_mode> [<registry_endpoint>]
 ```
 
-### Parameters
+### Auth command
 
-- **num_instances**: Number of instances to run. Optionally, specify batch size and interval.
-- **registry_domain**: Domain of the registry.
-- **token_mode**: Token mode. Options:
-  - `none`: No token.
-  - `anonymous`: Obtain an anonymous registry token to share between instances.
-  - `token=<token>`: Use the specified identity token to exchange a registry toekn and share between instances.
-- **registry_endpoint** (optional): Endpoint of the registry. Defaults to the registry domain.
+`auth` command cab be used to run authentication-related workloads against a registry. Please refer to `rlt auth -h` for more details.
 
-### Example
+### Pull command
 
-```bash
-#  runs 10 instances against `registry.example.com` without using any token.
-go run main.go 10 registry.example.com none
-
-# runs 100 instances against `registry.example.com`, starting 10 instances every 500 milliseconds using the specified token.
-go run main.go 100=10/500ms registry.example.com token=$registry_token
-
-# runs 50 instances against `registry.example.com` using shared anonymous access.
-go run main.go 50 registry.example.com anonymous
-
-# runs 20 instances against `registry.example.com` via a custom endpoint.
-go run main.go 20 registry.example.com none cus.fe.example.com
-```
+`pull` command can be used to run image pulling workloads against a registry. Please refer to `rlt pull -h` for more details.
 
 ## Notes
 

--- a/cmd/rlt/root/auth.go
+++ b/cmd/rlt/root/auth.go
@@ -23,8 +23,16 @@ func authCmd() *cobra.Command {
 	authCmd := &cobra.Command{
 		Use:   "auth  <num_instances>[=<size>/<duration>] <registry_domain>",
 		Short: "authenticate to a registry",
-		Long:  "run authentication workloads simultaneously with customized options",
-		Args:  cobra.ExactArgs(2),
+		Long: `run authentication workloads simultaneously with customized options
+
+Example - authenticate 10 images against registry.example.com without using any token.
+  rlt auth 10 registry.example.com
+Example - authenticate 100 images against registry.example.com, starting 10 instances every 500 milliseconds using the specified token.
+  rlt auth 100=10/500ms registry.example.com --refresh-token=$registry_token
+Example - authenticate 20 images against registry.example.com via a custom endpoint -e cus.fe.example.com.
+  rlt auth 20 registry.example.com none -e cus.fe.example.com
+`,
+		Args: cobra.ExactArgs(2),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Setup arguments
 			opts.Instance.SetFlag(args[0])

--- a/cmd/rlt/root/auth.go
+++ b/cmd/rlt/root/auth.go
@@ -27,8 +27,10 @@ func authCmd() *cobra.Command {
 
 Example - authenticate 10 images against registry.example.com without using any token.
   rlt auth 10 registry.example.com
+
 Example - authenticate 100 images against registry.example.com, starting 10 instances every 500 milliseconds using the specified token.
   rlt auth 100=10/500ms registry.example.com --refresh-token=$registry_token
+
 Example - authenticate 20 images against registry.example.com via a custom endpoint -e cus.fe.example.com.
   rlt auth 20 registry.example.com none -e cus.fe.example.com
 `,

--- a/cmd/rlt/root/pull.go
+++ b/cmd/rlt/root/pull.go
@@ -24,8 +24,23 @@ func pullCmd() *cobra.Command {
 	pullCmd := &cobra.Command{
 		Use:   "pull  <num_instances>[=<size>/<duration>] <registry_domain> <token_mode>",
 		Short: "pull from a registry",
-		Long:  "run pull workloads simultaneously with customized options",
-		Args:  cobra.MinimumNArgs(3),
+		Long: `run pull workloads simultaneously with customized options
+
+Example - pull 10 images against registry.example.com without using any token.
+  rlt pull 10 registry.example.com none
+Example - pull 100 images against registry.example.com, starting 10 instances every 500 milliseconds using the specified token.
+  rlt 100=10/500ms registry.example.com token=$registry_token
+
+Example - pull 50 images against registry.example.com using shared anonymous access.
+  rlt 50 registry.example.com anonymous
+
+Example - pull 20 images against registry.example.com via a custom endpoint -e cus.fe.example.com.
+  rlt 20 registry.example.com none cus.fe.example.com
+
+Example - pull 20 images against registry.example.com via a customize IP 192.168.1.1.
+  rlt 20 registry.example.com none cus.fe.example.com -e 192.168.1.1
+`,
+		Args: cobra.MinimumNArgs(3),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Setup arguments
 			opts.Instance.SetFlag(args[0])

--- a/cmd/rlt/root/pull.go
+++ b/cmd/rlt/root/pull.go
@@ -28,6 +28,7 @@ func pullCmd() *cobra.Command {
 
 Example - pull 10 images against registry.example.com without using any token.
   rlt pull 10 registry.example.com none
+
 Example - pull 100 images against registry.example.com, starting 10 instances every 500 milliseconds using the specified token.
   rlt 100=10/500ms registry.example.com token=$registry_token
 
@@ -35,10 +36,10 @@ Example - pull 50 images against registry.example.com using shared anonymous acc
   rlt 50 registry.example.com anonymous
 
 Example - pull 20 images against registry.example.com via a custom endpoint -e cus.fe.example.com.
-  rlt 20 registry.example.com none cus.fe.example.com
+  rlt 20 registry.example.com none -e cus.fe.example.com
 
 Example - pull 20 images against registry.example.com via a customize IP 192.168.1.1.
-  rlt 20 registry.example.com none cus.fe.example.com -e 192.168.1.1
+  rlt 20 registry.example.com none -e 192.168.1.1
 `,
 		Args: cobra.MinimumNArgs(3),
 		PreRunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
This pull request improves the documentation and user guidance for the registry load testing tool. The changes include restructuring the `README.md` for clarity, adding detailed usage examples for the `auth` and `pull` commands, and enhancing the help text for these commands in the CLI.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R27): Restructured the "Usage" section to separate "Build" and "Usage" instructions. Added new subsections for the `auth` and `pull` commands, directing users to the CLI help for more details. Removed parameter descriptions and examples, as these are now included in the CLI help.

### CLI Improvements:

* [`cmd/rlt/root/auth.go`](diffhunk://#diff-9b3f31b848ca0cbaefaabab3f93b5fea6c7b81ab6d1d4a887c26d5dfb804dee1L26-R34): Enhanced the `auth` command's `Long` description with detailed examples, including scenarios for using tokens, custom endpoints, and batch processing.
* [`cmd/rlt/root/pull.go`](diffhunk://#diff-577df6d594d4eb6361d0dce9ebbfc7de5f60b28f8a3a6aff91138d36a7c3f825L27-R42): Expanded the `pull` command's `Long` description to include multiple examples, covering various token modes, custom endpoints, and IP customization scenarios.